### PR TITLE
Add deploy script for continuous deployment with Travis

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Travis supports [continuous deployment](http://docs.travis-ci.com/user/deploymen
 Set up continuous deployment with the following settings in your `.travis.yml` file:
 
 ```yml
-before_install: npm install -g cf-blue-green
+sudo: true
 env:
   global:
   - CF_APP=[app name]
@@ -52,6 +52,7 @@ env:
   - CF_ORGANIZATION=[organization]
   - CF_SPACE=[space]
   - secure: [CF_PASSWORD=[encrypted with Travis](http://docs.travis-ci.com/user/environment-variables/#Encrypted-Variables)]
+before_deploy: npm install -g cf-blue-green
 deploy:
   provider: script
   script: cf-blue-green-travis

--- a/README.md
+++ b/README.md
@@ -36,6 +36,29 @@ The script is distributed via NPM, but doesn't actually require Node.js beyond t
 1. Run `chmod a+x cf-blue-green`.
 1. Move the file somewhere in your PATH.
 
+### Using with Travis
+
+Travis supports [continuous deployment](http://docs.travis-ci.com/user/deployment/), which will automatically deploy your application after its tests pass on a specified branch. To use `cf-blue-green` with Travis, you need to use a [script provider](http://docs.travis-ci.com/user/deployment/script/) instead of the default Cloud Foundry provider. Your Cloud Foundry settings are read from environment variables.
+
+Set up continuous deployment with the following settings in your `.travis.yml` file:
+
+```yml
+before_install: npm install -g cf-blue-green
+env:
+  global:
+  - CF_APP=[app name]
+  - CF_API=[API endpoint]
+  - CF_USERNAME=[user]
+  - CF_ORGANIZATION=[organization]
+  - CF_SPACE=[space]
+  - secure: [CF_PASSWORD=[encrypted with Travis](http://docs.travis-ci.com/user/environment-variables/#Encrypted-Variables)]
+deploy:
+  provider: script
+  script: cf-blue-green-travis
+  on:
+    branch: [git branch you want to deploy]
+```
+
 ### Manifests
 
 `cf-blue-green` creates a temporary manifest from your live application, meaning that it ignores the `manifest.yml` in your directory, if you have one. To deploy any changes to your manifest, use `cf push` directly.

--- a/bin/cf-blue-green-travis
+++ b/bin/cf-blue-green-travis
@@ -2,6 +2,10 @@
 
 set -e
 
+# Use the URL to a Debian 64 bit installer select from here:
+# https://github.com/cloudfoundry/cli/releases
+# This is the source file after following the redirect
+# Using v6.12.1 because of this: https://github.com/18F/cf-blue-green#cf-cli
 wget http://go-cli.s3-website-us-east-1.amazonaws.com/releases/v6.12.1/cf-cli_amd64.deb -qO temp.deb && sudo dpkg -i temp.deb
 
 rm temp.deb

--- a/bin/cf-blue-green-travis
+++ b/bin/cf-blue-green-travis
@@ -13,6 +13,11 @@ rm temp.deb
 cf api $CF_API
 cf login --u $CF_USERNAME --p $CF_PASSWORD --o $CF_ORGANIZATION --s $CF_SPACE
 
-./scripts/deploy.sh $CF_APP
+# Get path to script directory: http://stackoverflow.com/a/4774063
+pushd `dirname $0` > /dev/null
+SCRIPTPATH=`pwd`
+popd > /dev/null
+
+$SCRIPTPATH/cf-blue-green $CF_APP
 
 cf logout

--- a/bin/cf-blue-green-travis
+++ b/bin/cf-blue-green-travis
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+wget http://go-cli.s3-website-us-east-1.amazonaws.com/releases/v6.12.1/cf-cli_amd64.deb -qO temp.deb && sudo dpkg -i temp.deb
+
+rm temp.deb
+
+cf api $CF_API
+cf login --u $CF_USERNAME --p $CF_PASSWORD --o $CF_ORGANIZATION --s $CF_SPACE
+
+./scripts/deploy.sh $CF_APP
+
+cf logout

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cf-blue-green",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "zero-downtime deployment for Cloud Foundry applications",
   "repository": {
     "type": "git",
@@ -19,6 +19,7 @@
   },
   "homepage": "https://github.com/18F/cf-blue-green#readme",
   "bin": {
-    "cf-blue-green": "./bin/cf-blue-green"
+    "cf-blue-green": "./bin/cf-blue-green",
+    "cf-blue-green-travis": "./bin/cf-blue-green-travis"
   }
 }


### PR DESCRIPTION
Adds a script and instructions for continuous deployment with Travis. 

Added to the readme:
### Using with Travis

Travis supports [continuous deployment](http://docs.travis-ci.com/user/deployment/), which will automatically deploy your application after its tests pass on a specified branch. To use `cf-blue-green` with Travis, you need to use a [script provider](http://docs.travis-ci.com/user/deployment/script/) instead of the default Cloud Foundry provider. Your Cloud Foundry settings are read from environment variables.

Set up continuous deployment with the following settings in your `.travis.yml` file:

``` yml
before_install: npm install -g cf-blue-green
env:
  global:
  - CF_APP=[app name]
  - CF_API=[API endpoint]
  - CF_USERNAME=[user]
  - CF_ORGANIZATION=[organization]
  - CF_SPACE=[space]
  - secure: [CF_PASSWORD=[encrypted with Travis](http://docs.travis-ci.com/user/environment-variables/#Encrypted-Variables)]
deploy:
  provider: script
  script: cf-blue-green-travis
  on:
    branch: [git branch you want to deploy]
```
