### PR TITLE
Allow domain to be set by env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,19 @@ deploy:
 
 `cf-blue-green` creates a temporary manifest from your live application, meaning that it ignores the `manifest.yml` in your directory, if you have one. To deploy any changes to your manifest, use `cf push` directly.
 
+## Multiple domains
+
+The script fails on apps with multiple domains, because the domains in the manifest are in the form of a list:
+
+```yml
+domain:
+  - 18f.gov
+  - digitalgov.gov
+```
+
+To work around this, use the env var `B_DOMAIN` for the domain you'd like the B instance to use.
+
+
 ## Resources
 
 More information about blue-green deployment, all of which this script drew from.

--- a/bin/cf-blue-green
+++ b/bin/cf-blue-green
@@ -39,7 +39,7 @@ cf create-app-manifest $BLUE -p $MANIFEST
 # http://stackoverflow.com/a/185900/358804
 trap on_fail ERR
 
-DOMAIN=$(cat $MANIFEST | grep domain: | awk '{print $2}')
+DOMAIN=${B_DOMAIN:-$(cat $MANIFEST | grep domain: | awk '{print $2}')}
 
 # create the GREEN application
 cf push $GREEN -f $MANIFEST -n $GREEN


### PR DESCRIPTION
The script fails on apps with multiple domains, because the domains in the manifest are in the form of a list:

``` yml
domain:
  - 18f.gov
  - digitalgov.gov
```

Example: https://travis-ci.org/18F/midas/#L906

To work around this, this PR will use the env var `B_DOMAIN` for the domain if available; otherwise it does the usual manifest file parsing.
