### PR TITLE
Add an sleep command for applications with multiple instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ env:
   - CF_USERNAME=[user]
   - CF_ORGANIZATION=[organization]
   - CF_SPACE=[space]
+  - CF_SLEEP=[# seconds to wait before swapping BLUE with GREEN]
   - secure: [CF_PASSWORD=[encrypted with Travis](http://docs.travis-ci.com/user/environment-variables/#Encrypted-Variables)]
 before_deploy: npm install -g cf-blue-green
 deploy:
@@ -46,6 +47,8 @@ deploy:
   on:
     branch: [git branch you want to deploy]
 ```
+
+`CF_SLEEP` defines the number of seconds to sleep before replacing BLUE with GREEN. Useful when the new application requires some time to start.
 
 ### Manifests
 

--- a/bin/cf-blue-green
+++ b/bin/cf-blue-green
@@ -45,7 +45,7 @@ DOMAIN=${B_DOMAIN:-$(cat $MANIFEST | grep domain: | awk '{print $2}')}
 cf push $GREEN -f $MANIFEST -n $GREEN
 
 # wait for the apps to start
-sleep ${5:-CF_SLEEP}s # Waits 5 seconds.
+sleep ${CF_SLEEP:-5} # Waits 5 seconds.
 
 # ensure it starts
 curl --fail -I "https://${GREEN}.${DOMAIN}"

--- a/bin/cf-blue-green
+++ b/bin/cf-blue-green
@@ -43,6 +43,10 @@ DOMAIN=${B_DOMAIN:-$(cat $MANIFEST | grep domain: | awk '{print $2}')}
 
 # create the GREEN application
 cf push $GREEN -f $MANIFEST -n $GREEN
+
+# wait for the apps to start
+sleep ${5:-CF_SLEEP}s # Waits 5 seconds.
+
 # ensure it starts
 curl --fail -I "https://${GREEN}.${DOMAIN}"
 


### PR DESCRIPTION
`cf push` will return as soon as some of the instances are running. If we don't wait until all of them start then we could execute `curl --fail -I "https://${GREEN}.${DOMAIN}"` and get a  response different than 200.

This pull request adds an option to sleep for `CF_SLEEP` seconds (default to 5).

I'm testing it on one of my projects and It's working fine. 
Let me know if you don't like the variable name.